### PR TITLE
Don't run CI when creating tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Just a minor change. The CI shouldn't run when pushing to `v*` tags.